### PR TITLE
Include note about port number

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,7 @@
 ```viml
 let g:fugitive_bitbucketservers_domains = ['http://yoururl.com'] 
 ```
+If your server URL includes a port as well as the hostname e.g. http://yoururl.com:7990 then just the hostname should be configured, don't include the ":7990".
+
 ## originaly form
 tommcdo/vim-fubitive


### PR DESCRIPTION
When the fugitive_bitbucketservers_domains URL includes a port number the matching against the remote URL doesn't work properly, which in my case meant the URL was accessed as https rather than http, which didn't work.